### PR TITLE
Gps Raw data

### DIFF
--- a/bolt-ons/gps-bolt-on/Gps_Raw_Data.ino
+++ b/bolt-ons/gps-bolt-on/Gps_Raw_Data.ino
@@ -1,0 +1,15 @@
+#include <SoftwareSerial.h>
+
+SoftwareSerial gpsSerial(17, 18);  // RX, TX
+
+void setup() {
+  Serial.begin(115200);    // Initialize serial communication with the Serial Monitor
+  gpsSerial.begin(115200); // Initialize serial communication with the GPS module
+}
+
+void loop() {
+  if (gpsSerial.available()) {  // Check if data is available from the GPS module
+    char c = gpsSerial.read();  // Read a character from the GPS module 
+    Serial.print(c);            // Print the character to the Serial Monitor (Raw Data)
+  }
+}


### PR DESCRIPTION
To read raw data from a GPS module, there are two methods:

Direct Connection to ESP32:

Connect the GPS module's RX and TX pins directly to the ESP32's TX and RX pins, respectively.
With some simple coding, you can read the GPS data using the Serial Monitor.
Using a UART Converter:

Utilize a UART converter to interface the GPS module.
In this setup, a microcontroller is not required. The computer can directly read data from the USB port where the UART converter is connected.
